### PR TITLE
Fix CV page alt attributes and typo

### DIFF
--- a/src/components/Curriculum.astro
+++ b/src/components/Curriculum.astro
@@ -38,7 +38,7 @@
 				<div class='item item1 der'>
 					<h4>Desarrollador Backend Spring</h4>
 					<span class='casa'>NTT Data</span>
-					<span class='fecha'>Feb 2023 - Acualidad</span>
+                                        <span class='fecha'>Feb 2023 - Actualidad</span>
 					<ul>
 						<li>Java</li>
 						<li>Spring</li>

--- a/src/components/CvPage.astro
+++ b/src/components/CvPage.astro
@@ -10,9 +10,9 @@ import cv3 from '../assets/img/CV_Javier_Curto_Brull_page-0003.jpg';
 		<h1>Curriculum Vitae de Javier Curto</h1>
 
 		<div id="image-viewer" class='image-viewer'>
-			<Image src={cv1} alt='Retrato de Javier Curto Brull' alt='CV Page 1' class='cv-image' loading='eager' />
-			<Image src={cv2} alt='Retrato de Javier Curto Brull' alt='CV Page 2' class='cv-image' loading='lazy' />
-			<Image src={cv3} alt='Retrato de Javier Curto Brull' alt='CV Page 3' class='cv-image' loading='lazy' />
+                        <Image src={cv1} alt='CV Page 1' class='cv-image' loading='eager' />
+                        <Image src={cv2} alt='CV Page 2' class='cv-image' loading='lazy' />
+                        <Image src={cv3} alt='CV Page 3' class='cv-image' loading='lazy' />
 		</div>
 		
 		<p>Si deseas descargar el CV, haz clic en el siguiente botón:</p>


### PR DESCRIPTION
## Summary
- fix duplicate `alt` attributes in `CvPage.astro`
- correct typo "Acualidad" -> "Actualidad" in `Curriculum.astro`

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68475e3c19008333a2d9d94f41c5bb52